### PR TITLE
Don't ignore the value of TORCH_CUDA_ARCH_LIST at build time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ def ext_modules():
             cpp_extension.CUDAExtension(
                 "torchsort.isotonic_cuda",
                 sources=["torchsort/isotonic_cuda.cu"],
-                extra_compile_args=["-arch=compute_50"],
             ),
         )
     return extensions


### PR DESCRIPTION
### Problem

When building the package for compatibility with multiple GPU architectures,  the environment variable `TORCH_CUDA_ARCH_LIST` is ignored since `extra_compile_args=["-arch="compute_50"]` is already set in setup.py.

### Fix
Don't explicitly define a compute architecture in the extension's cflags.


### Demonstration of correctness
Original code:
```
$ `TORCH_CUDA_ARCH_LIST="Maxwell;Volta;Kepler" python setup.py build
$ cuobjdump build/lib.linux-x86_64-3.6/torchsort/isotonic_cuda.cpython-36m-x86_64-linux-gnu.so

Fatbin ptx code:
================
arch = sm_50
code version = [6,5]
producer = <unknown>
host = linux
compile_size = 64bit
compressed
```

With this PR, code for all the requested architectures is included in the built library:

```
$ `TORCH_CUDA_ARCH_LIST="Maxwell;Volta;Kepler" python setup.py build
$ cuobjdump build/lib.linux-x86_64-3.6/torchsort/isotonic_cuda.cpython-36m-x86_64-linux-gnu.so

Fatbin ptx code:
================
arch = sm_35
code version = [6,5]
producer = <unknown>
host = linux
compile_size = 64bit
compressed

Fatbin elf code:
================
arch = sm_35
code version = [1,7]
producer = <unknown>
host = linux
compile_size = 64bit

Fatbin elf code:
================
arch = sm_70
code version = [1,7]
producer = <unknown>
host = linux
compile_size = 64bit

Fatbin ptx code:
================
arch = sm_70
code version = [6,5]
producer = <unknown>
host = linux
compile_size = 64bit
compressed

Fatbin elf code:
================
arch = sm_50
code version = [1,7]
producer = <unknown>
host = linux
compile_size = 64bit

Fatbin elf code:
================
arch = sm_52
code version = [1,7]
producer = <unknown>
host = linux
compile_size = 64bit

Fatbin ptx code:
================
arch = sm_52
code version = [6,5]
producer = <unknown>
host = linux
compile_size = 64bit
compressed
```

The default behavior of building for the host GPU's architecture if no options are specified is preserved.
Building on a system with a Tesla M60 (arch 5.2):
```
python setup.py build
$ cuobjdump build/lib.linux-x86_64-3.6/torchsort/isotonic_cuda.cpython-36m-x86_64-linux-gnu.so


Fatbin elf code:
================
arch = sm_52
code version = [1,7]
producer = <unknown>
host = linux
compile_size = 64bit
```

### Why this is happening
In `torch.utils.cpp_extension`, the function `_get_cuda_arch_flags` is invoked to prepare the `-arch=` flags to give `nvcc`. If any existing flag contains the string "arch" this function will exit instead of checking the environment variable. It makes sense that this function treats user provided cflags as superseding environment variables, but accordingly the setup file should not provide the flag.