### PR TITLE
Prebuilt release naming convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,10 @@ jobs:
         os: [ubuntu-20.04]
         python-version: ['3.10', '3.11']
         torch-version: ['1.13.1', '2.0.1']
-        cuda-version: ['cpu', 'cu113', 'cu117', 'cu118']
+        cuda-version: ['cpu', 'cu117', 'cu118']
         exclude:
           - torch-version: 1.13.1
             cuda-version: cu118
-          - torch-version: 2.0.1
-            cuda-version: cu113
     steps:
       - name: Free disk space
         run: |
@@ -57,7 +55,7 @@ jobs:
         run: |
           export FORCE_CUDA=1
           export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
-          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/..$//" | sed "s/\.//g"`
+          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' | sed "s/\.//g"
           CUDA_VERSION=`echo ${{ matrix.cuda-version }}`
           export TORCHSORT_VERSION_SUFFIX="+$TORCH_VERSION$CUDA_VERSION"
           python3 -m pip install wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export FORCE_CUDA=1
           export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
-          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' | sed "s/\.//g"
+          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/^\([0-9]\+\.[0-9]\+\).*$/\1/" | sed "s/\.//g"`
           CUDA_VERSION=`echo ${{ matrix.cuda-version }}`
           export TORCHSORT_VERSION_SUFFIX="+$TORCH_VERSION$CUDA_VERSION"
           python3 -m pip install wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
           TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/..$//" | sed "s/\.//g"`
           CUDA_VERSION=`echo ${{ matrix.cuda-version }}`
-          export TORCHSORT_VERSION_SUFFIX: "+$TORCH_VERSION$CUDA_VERSION"
+          export TORCHSORT_VERSION_SUFFIX="+$TORCH_VERSION$CUDA_VERSION"
           python3 -m pip install wheel
           python3 setup.py bdist_wheel --dist-dir=dist
           echo "distname=$(ls dist)" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
         run: |
           export FORCE_CUDA=1
           export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
+          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/..$//" | sed "s/\.//g"`
+          CUDA_VERSION=`echo ${{ matrix.cuda-version }}`
+          export TORCHSORT_VERSION_SUFFIX: "+$TORCH_VERSION$CUDA_VERSION"
           python3 -m pip install wheel
           python3 setup.py bdist_wheel --dist-dir=dist
           echo "distname=$(ls dist)" >> ${GITHUB_OUTPUT}

--- a/README.md
+++ b/README.md
@@ -35,13 +35,31 @@ environments. If this happens you may need to:
 Thanks to @levnikmyskin, @sachit-menon for pointing this out!
 </details>
 
+### Pre-built Wheels
+
+Pre-built wheels are currently available on Linux for some Python/PyTorch/CUDA combinations:
+
+```bash
+# torchsort version, supports >= 1.9.0
+export TORCHSORT=1.9.0
+# PyTorch version, supports pt20 and pt113 for versions 2.0 and 1.13 respectively
+export TORCH=pt20
+# CUDA version, supports cpu, cu113, cu117, cu118 for CPU-only, CUDA 11.3, CUDA 11.7 and CUDA 11.8 respectively
+export CUDA=cu118
+# Python version, supports cp310 and cp311 for versions 3.10 and 3.11 respectively
+export PYTHON=cp310
+
+pip install https://github.com/teddykoker/torchsort/releases/download/v${TORCHSORT}/torchsort-${TORCHSORT}+${TORCH}${CUDA}-${PYTHON}-${PYTHON}-linux_x86_64.whl
+```
+
+
 
 ## Usage
 
 `torchsort` exposes two functions: `soft_rank` and `soft_sort`, each with
 parameters `regularization` (`"l2"` or `"kl"`) and `regularization_strength` (a
 scalar value). Each will rank/sort the last dimension of a 2-d tensor, with an
-accuracy dependant upon the regularization strength:
+accuracy dependent upon the regularization strength:
 
 ```python
 import torch


### PR DESCRIPTION
Align closer to the [Wheel Naming Convention](https://peps.python.org/pep-0491/#file-name-convention) and `torch`'s naming convention. For example the version built with `torch` 1.13, CUDA 11.7 and Python 3.10 would have the following name:

 `torchsort-0.1.9+pt113cu117-cp310-cp310-linux_x86_64.whl` 