### PR TITLE
Add pyproject.toml for PEP 517 builds and project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = [
+    "setuptools>=61.0",
+    "wheel",
+    "torch>=1.7.1"  # Required for torch.utils.cpp_extension during build
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "torchsort"
+dynamic = ["version"]  # Version is defined in setup.py and read by setuptools
+description = "Differentiable sorting and ranking in PyTorch"
+readme = "README.md"
+requires-python = ">=3.7"
+license = { file = "LICENSE" } # Assumes LICENSE file contains Apache-2.0 text
+authors = [
+    { name = "Teddy Koker" }
+]
+keywords = ["pytorch", "sorting", "ranking", "differentiable", "cuda", "isotonic regression"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: C++",
+    "Framework :: PyTorch",
+]
+dependencies = [
+    "torch>=1.7.1"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/teddykoker/torchsort"
+"Repository" = "https://github.com/teddykoker/torchsort"
+"Bug Tracker" = "https://github.com/teddykoker/torchsort/issues"
+
+[project.optional-dependencies]
+testing = [
+    "pytest",
+    "fast_soft_sort @ git+https://github.com/google-research/fast-soft-sort.git@6a52ce79869ab16e1e0f39149a84f50f8ad648c5"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,29 +12,12 @@ dynamic = ["version"]  # Version is defined in setup.py and read by setuptools
 description = "Differentiable sorting and ranking in PyTorch"
 readme = "README.md"
 requires-python = ">=3.7"
-license = { file = "LICENSE" } # Assumes LICENSE file contains Apache-2.0 text
+license = { file = "LICENSE" }
 authors = [
     { name = "Teddy Koker" }
 ]
-keywords = ["pytorch", "sorting", "ranking", "differentiable", "cuda", "isotonic regression"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: C++",
-    "Framework :: PyTorch",
+    "Programming Language :: Python :: 3"
 ]
 dependencies = [
     "torch>=1.7.1"


### PR DESCRIPTION
Allows for simple `pip install git+https://github.com/teddykoker/torchsort` without errors.

(Sorry for the last failed PR, I messed it up trying to update my author email, could you remove it?)

By the way, do you think you could make a new release with the wheels for the newer versions of Python and CUDA (I believe you have already the code for that with commit [c5474f2](https://github.com/teddykoker/torchsort/commit/c5474f2030dca94c25acbe2f31b0dac4c77ddadd)). It would be convenient for using on HPCs without CUDA toolchain.